### PR TITLE
integration_tests_working_jcamp

### DIFF
--- a/postgresql_integration_test/postgresql.py
+++ b/postgresql_integration_test/postgresql.py
@@ -6,6 +6,7 @@ import time
 import getpass
 import os
 import signal
+import socket
 import subprocess
 import psycopg2
 from datetime import datetime
@@ -229,4 +230,8 @@ class PostgreSQL:
             time.sleep(0.5)
 
     def is_server_available(self):
-        return os.path.exists(os.path.join(self.config.dirs.data_dir, f".s.PGSQL.{self.config.database.port}"))
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(1)
+            result = sock.connect_ex((self.config.database.host, self.config.database.port))
+            return result == 0
+

--- a/postgresql_integration_test/postgresql.py
+++ b/postgresql_integration_test/postgresql.py
@@ -58,19 +58,23 @@ class PostgreSQL:
 
         self.owner_pid = os.getpid()
 
-        logger.debug("Creating application directories")
+        # Create temporary directories
+        logger.debug(f"Creating application directories in {self.config.dirs.tmp_dir}")
         os.mkdir(self.config.dirs.tmp_dir)
         os.chmod(self.config.dirs.tmp_dir, 0o700)
         os.mkdir(self.config.dirs.etc_dir)
         os.mkdir(self.config.dirs.data_dir)
 
+        # Run initdb
         try:
             logger.debug("Initializing PostgreSQL w/initdb")
             pgsql_command_line = [
                 shutil.which("initdb"),
-                f"-g",
-                f"-D {os.path.join(self.config.dirs.data_dir)}",
-                f"-U {self.user}",
+                "-g",
+                "-D",
+                os.path.join(self.config.dirs.data_dir),
+                "-U",
+                self.user,
             ]
             logger.debug(f"PG_CTL_INITDB_CMD: {pgsql_command_line}")
             process = subprocess.Popen(
@@ -78,53 +82,27 @@ class PostgreSQL:
             )
 
             (output, error) = process.communicate()
-            if error is not None:
-                logger.debug(f"PostgreSQL initdb error: {output} {error}")
+            if not process.returncode == 0:
+              raise RuntimeError(f"Error initing PostgreSQL w/initdb: {exc}")
         except Exception as exc:
-            raise RuntimeError(f"Initializing PostgreSQL w/initdb: {exc}")
+            raise RuntimeError(f"Error initing PostgreSQL w/initdb: {exc}")
 
-        try:
-            logger.debug(f"Creating role {self.user}")
 
-            pgsql_command_line = [
-                shutil.which("createuser"),
-                f"-U {self.user}",
-                self.user,
-            ]
-
-            process = subprocess.Popen(
-                pgsql_command_line, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
-            )
-
-            (output, error) = process.communicate()
-            if error is not None:
-                logger.debug(f"Creating role error: {output} {error}")
-        except Exception as exc:
-            raise RuntimeError(f"Failed creating role: {self.config.database.name}")
-
-        try:
-            logger.debug("Creating Database 'test'")
-            pgsql_command_line = [
-                shutil.which("createdb"),
-                f"-U {self.user}",
-                "test",
-            ]
-            process = subprocess.Popen(
-                pgsql_command_line, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
-            )
-            (output, error) = process.communicate()
-            if error is not None:
-                logger.debug(f"PosgreSQL createdb error: {output} {error}")
-        except Exception as exc:
-            raise RuntimeError(f"Failed creating database: {self.config.database}")
-
+        # Start postgreSQL
         try:
             logger.debug(
                 f"Starting PostgreSQL at {os.path.join(self.config.dirs.data_dir)}"
             )
             pgsql_command_line = [
                 shutil.which("postgres"),
-                f"-D {os.path.join(self.config.dirs.data_dir)}",
+                "-D",
+                os.path.join(self.config.dirs.data_dir),
+                "-h",
+                "localhost",
+                "-p",
+                str(self.config.database.port),
+                "-k",
+                os.path.join(self.config.dirs.data_dir),
             ]
             logger.debug(f"PG_CTL_START_CMD: {pgsql_command_line}")
             self.child_process = subprocess.Popen(
@@ -138,6 +116,58 @@ class PostgreSQL:
             except Exception:
                 self.stop()
                 raise
+
+
+        # Create the role user
+        try:
+            logger.debug(f"Creating role {self.user}")
+
+            pgsql_command_line = [
+                shutil.which("createuser"),
+                "-U",
+                self.user,
+                "-h",
+                "localhost",
+                "-p",
+                str(self.config.database.port),
+                self.user,
+            ]
+            logger.debug(f"CREATEUSER_CMD: {pgsql_command_line}")
+
+            process = subprocess.Popen(
+                pgsql_command_line, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+            )
+
+            (output, error) = process.communicate()
+            if not process.returncode == 0:
+                logger.debug(f"Creating role error: {output} {error}")
+        except Exception as exc:
+            raise RuntimeError(f"Failed creating role: {self.config.database.name}")
+
+
+        # Create the test database
+        try:
+            logger.debug("Creating Database 'test'")
+            pgsql_command_line = [
+                shutil.which("createdb"),
+                "-U",
+                self.user,
+                "-h",
+                "localhost",
+                "-p",
+                str(self.config.database.port),
+                "test",
+            ]
+            logger.debug(f"CREATEDB_CMD: {pgsql_command_line}")
+            process = subprocess.Popen(
+                pgsql_command_line, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+            )
+            (output, error) = process.communicate()
+            if not process.returncode == 0:
+                logger.debug(f"PosgreSQL createdb error: {output} {error}")
+        except Exception as exc:
+            raise RuntimeError(f"Failed creating database: {self.config.database}")
+
 
         instance_config = ConfigInstance(
             {
@@ -199,4 +229,4 @@ class PostgreSQL:
             time.sleep(0.5)
 
     def is_server_available(self):
-        return "postgres" in (i.name() for i in psutil.process_iter())
+        return os.path.exists(os.path.join(self.config.dirs.data_dir, f".s.PGSQL.{self.config.database.port}"))

--- a/postgresql_integration_test/settings.py
+++ b/postgresql_integration_test/settings.py
@@ -91,7 +91,7 @@ class ConfigFile:
         self.dirs.tmp_dir = os.path.join(self.dirs.base_dir, "tmp")
 
         self.database = ConfigAttribute()
-        self.database.host = os.path.join(self.dirs.base_dir, "tmp")
+        self.database.host = "localhost"
         self.database.port = Utils.get_unused_port()
         self.database.name = getpass.getuser()
         self.database.username = getpass.getuser()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,7 +6,7 @@ from postgresql_integration_test.postgresql import PostgreSQL
 
 
 @pytest.fixture
-def pgsql_connect(autouse=True):
+def pgsql_connect():
     pgsql = PostgreSQL()
     return pgsql.run()
 
@@ -14,7 +14,8 @@ def pgsql_connect(autouse=True):
 def execute_query(pgsql, query):
     cnx = psycopg2.connect(
         user=pgsql.username,
-        host="/tmp",
+        host=pgsql.host,
+        port=pgsql.port,
         database="test",
     )
     cursor = cnx.cursor()
@@ -27,7 +28,8 @@ def execute_query(pgsql, query):
 def select_query(pgsql, query):
     cnx = psycopg2.connect(
         user=pgsql.username,
-        host="/tmp",
+        host=pgsql.host,
+        port=pgsql.port,
         database="test",
     )
     cursor = cnx.cursor()
@@ -50,7 +52,7 @@ def test_pgsql_endtoend(pgsql_connect):
 def test_pgsql_create_table(pgsql_connect):
     execute_query(
         pgsql_connect,
-        "CREATE TABLE pytest_test (id serial primary key, sometext text)",
+        "CREATE TABLE test (id serial primary key, sometext text)",
     )
     assert True
 
@@ -58,13 +60,25 @@ def test_pgsql_create_table(pgsql_connect):
 @pytest.mark.integration_test
 def test_pgsql_insert_into_table(pgsql_connect):
     execute_query(
-        pgsql_connect, "INSERT INTO pytest_test (sometext) VALUES ('this is some text')"
+        pgsql_connect,
+        "CREATE TABLE test (id serial primary key, sometext text)",
+    )
+    execute_query(
+        pgsql_connect, "INSERT INTO test (sometext) VALUES ('this is some text')"
     )
     assert True
 
 
 @pytest.mark.integration_test
 def test_pgsql_select_from_table(pgsql_connect):
-    select_id = select_query(pgsql_connect, "SELECT id FROM pytest_test")
+    execute_query(
+        pgsql_connect,
+        "CREATE TABLE test (id serial primary key, sometext text)",
+    )
+    execute_query(
+        pgsql_connect, "INSERT INTO test (sometext) VALUES ('this is some text')"
+    )
+
+    select_id = select_query(pgsql_connect, "SELECT id FROM test")
 
     assert select_id == 1


### PR DESCRIPTION
- Split arguments apart because it wouldn't work on linux
- Added better logic to see if the server is up
- Added host and port to postgres startup
- Fixed integration tests (the unfortunately start up a separate postgres instance for each one, so we need to perform all operations for each test)